### PR TITLE
Add line option to limit lines to display

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,9 @@ use rev_lines::{RevLines, RevLinesError};
 struct Args {
     /// Name of the file to read. If not specified, reads from stdin.
     name: Option<String>,
+    /// Number of lines to display.
+    #[clap(short, long)]
+    lines: Option<usize>,
 }
 
 fn main() {
@@ -22,8 +25,13 @@ fn main() {
         None => read_from_stdin(),
         Some(file_name) => read_from_file(file_name),
     };
+    // limit lines if line option is specified
+    let lines = match args.lines {
+        None => rev_lines,
+        Some(n) => Box::new(rev_lines.take(n)),
+    };
 
-    for line in rev_lines {
+    for line in lines {
         println!("{}", line.unwrap());
     }
 }


### PR DESCRIPTION
Closed : #6 
- add --line ( or -l ) option in CLI to limit number of lines to display
- if No line option is specified it will default to old behavior i.e. all lines

<img width="290" alt="image" src="https://github.com/lpicanco/rcat/assets/25602698/d90b6844-0f3f-48a7-869d-ab76a657b580">

If task is done, kindly approve PR , I am taking part in hacktoberfest :)